### PR TITLE
Deploy by git ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: go
 go:
   - '1.8.3'
-cache:
-  directories:
-    - vendor
 install:
   - make deps
 script:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -105,6 +105,18 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  revision = "00874eae3fbfc6750bfff364b1897101684d2f30"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
@@ -232,6 +244,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a80a5548ca1258f111dc7a9687c24a4762f4dfcc06657d2cb8cf35304fcfd8e6"
+  inputs-digest = "aadfc9b780c7ce8e6502a10d8436e83c1b718dfdbefa110adf38e32f7f77cf02"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -1,0 +1,39 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// refCmd represents the ref command
+var refCmd = &cobra.Command{
+	Use:   "ref",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("ref called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(refCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// refCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// refCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -93,7 +93,7 @@ func init() {
 	refCmd.Flags().StringVarP(&refOpts.container, "container", "c", "", "target container")
 	refCmd.Flags().StringVarP(&refOpts.deployment, "deployment", "d", "", "target Deployment")
 	refCmd.Flags().BoolVar(&refOpts.dryRun, "dry-run", false, "dry run")
-	refCmd.Flags().StringVar(&refOpts.namespace, "namespace", kubernetes.DefaultNamespace(), "Kubernetes namespace")
+	refCmd.Flags().StringVarP(&refOpts.namespace, "namespace", "n", kubernetes.DefaultNamespace(), "Kubernetes namespace")
 
 	if refOpts.accessToken == "" {
 		refOpts.accessToken = os.Getenv("GITHUB_ACCESS_TOKEN")

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -63,7 +63,7 @@ func doRef(cmd *cobra.Command, args []string) error {
 
 	sha1, err := ghClient.CommitFronRef(repo, ref)
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve commit SHA-1")
+		return errors.Wrapf(err, "failed to retrieve commit SHA-1 matched to ref %q in repo %q", ref, repo)
 	}
 
 	currentImage := kubernetes.ContainerImageFromDeployment(deployment, container.Name)

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -38,12 +38,12 @@ func doRef(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}
 
-	deployment, err := k8sClient.DetectTargetDeployment(deployOpts.namespace, deployOpts.deployment)
+	deployment, err := k8sClient.DetectTargetDeployment(refOpts.namespace, refOpts.deployment)
 	if err != nil {
 		return errors.Wrap(err, "failed to detect target Deployment")
 	}
 
-	container, err := k8sClient.DetectTargetContainer(deployment, deployOpts.container)
+	container, err := k8sClient.DetectTargetContainer(deployment, refOpts.container)
 	if err != nil {
 		return errors.Wrap(err, "failed to detect target container")
 	}
@@ -69,7 +69,7 @@ func doRef(cmd *cobra.Command, args []string) error {
 	currentImage := kubernetes.ContainerImageFromDeployment(deployment, container.Name)
 	newImage := strings.Split(currentImage, ":")[0] + ":" + sha1
 
-	if deployOpts.dryRun {
+	if refOpts.dryRun {
 		fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", deployment.Name, container.Name)
 		fmt.Printf("[dry-run]  before: %s\n", container.Image)
 		fmt.Printf("[dry-run]   after: %s\n", newImage)

--- a/github/client.go
+++ b/github/client.go
@@ -4,12 +4,14 @@ import (
 	"context"
 
 	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
 // Client represents the wrapper of GitHub API client
 type Client struct {
 	client *github.Client
+	ctx    context.Context
 }
 
 // NewClient creates new Client object
@@ -22,5 +24,17 @@ func NewClient(ctx context.Context, accesToken string) *Client {
 
 	return &Client{
 		client: client,
+		ctx:    ctx,
 	}
+}
+
+// CommitFronRef returns the latest commit SHA-1 of the given ref
+// (branch, full commit SHA-1, short commit SHA-1...)
+func (c *Client) CommitFronRef(owner, repo, ref string) (string, error) {
+	sha1, _, err := c.client.Repositories.GetCommitSHA1(c.ctx, owner, repo, ref, "")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to retrieve commit SHA-1")
+	}
+
+	return sha1, nil
 }

--- a/github/client.go
+++ b/github/client.go
@@ -1,0 +1,26 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// Client represents the wrapper of GitHub API client
+type Client struct {
+	client *github.Client
+}
+
+// NewClient creates new Client object
+func NewClient(ctx context.Context, accesToken string) *Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: accesToken,
+	})
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	return &Client{
+		client: client,
+	}
+}

--- a/github/client.go
+++ b/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
@@ -30,8 +31,13 @@ func NewClient(ctx context.Context, accesToken string) *Client {
 
 // CommitFronRef returns the latest commit SHA-1 of the given ref
 // (branch, full commit SHA-1, short commit SHA-1...)
-func (c *Client) CommitFronRef(owner, repo, ref string) (string, error) {
-	sha1, _, err := c.client.Repositories.GetCommitSHA1(c.ctx, owner, repo, ref, "")
+func (c *Client) CommitFronRef(repo, ref string) (string, error) {
+	ss := strings.Split(repo, "/")
+	if len(ss) != 2 {
+		return "", errors.Errorf("invalid repository %q, must be owner/repo", repo)
+	}
+
+	sha1, _, err := c.client.Repositories.GetCommitSHA1(c.ctx, ss[0], ss[1], ref, "")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to retrieve commit SHA-1")
 	}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	githubLabel = "github"
+	githubAnnotation = "github"
 )
 
 // DefaultConfigFile returns the default kubeconfig file path
@@ -34,11 +34,11 @@ func ContainerImageFromDeployment(deployment *v1beta1.Deployment, container stri
 	return ""
 }
 
-// RepositoriesFromDeployment returns the reportories attached by 'github' label
+// RepositoriesFromDeployment returns the reportories attached by 'github' annotation
 func RepositoriesFromDeployment(deployment *v1beta1.Deployment) (map[string]string, error) {
-	v, ok := deployment.Labels[githubLabel]
+	v, ok := deployment.Annotations[githubAnnotation]
 	if !ok {
-		return map[string]string{}, errors.Errorf("label %q not found in deployment %q", githubLabel, deployment.Name)
+		return map[string]string{}, errors.Errorf("annotation %q not found in Deployment %q", githubAnnotation, deployment.Name)
 	}
 
 	repos := map[string]string{}
@@ -46,7 +46,7 @@ func RepositoriesFromDeployment(deployment *v1beta1.Deployment) (map[string]stri
 	for _, f := range strings.Split(v, ",") {
 		ss := strings.Split(f, ":")
 		if len(ss) != 2 {
-			return map[string]string{}, errors.Errorf(`invalid label %q value %q, must be "container=owner/repo"`, githubLabel, f)
+			return map[string]string{}, errors.Errorf(`invalid annotation %q value %q, must be "container=owner/repo"`, githubAnnotation, f)
 		}
 		repos[ss[0]] = ss[1]
 	}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -44,7 +44,7 @@ func RepositoriesFromDeployment(deployment *v1beta1.Deployment) (map[string]stri
 	repos := map[string]string{}
 
 	for _, f := range strings.Split(v, ",") {
-		ss := strings.Split(f, ":")
+		ss := strings.Split(f, "=")
 		if len(ss) != 2 {
 			return map[string]string{}, errors.Errorf(`invalid annotation %q value %q, must be "container=owner/repo"`, githubAnnotation, f)
 		}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -1,9 +1,16 @@
 package kubernetes
 
 import (
+	"strings"
+
+	"github.com/pkg/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	githubLabel = "github"
 )
 
 // DefaultConfigFile returns the default kubeconfig file path
@@ -25,4 +32,24 @@ func ContainerImageFromDeployment(deployment *v1beta1.Deployment, container stri
 	}
 
 	return ""
+}
+
+// RepositoriesFromDeployment returns the reportories attached by 'github' label
+func RepositoriesFromDeployment(deployment *v1beta1.Deployment) (map[string]string, error) {
+	v, ok := deployment.Labels[githubLabel]
+	if !ok {
+		return map[string]string{}, errors.Errorf("label %q not found in deployment %q", githubLabel, deployment.Name)
+	}
+
+	repos := map[string]string{}
+
+	for _, f := range strings.Split(v, ",") {
+		ss := strings.Split(f, ":")
+		if len(ss) != 2 {
+			return map[string]string{}, errors.Errorf(`invalid label %q value %q, must be "container=owner/repo"`, githubLabel, f)
+		}
+		repos[ss[0]] = ss[1]
+	}
+
+	return repos, nil
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -63,7 +63,7 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 					Name:      "deployment",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"github": "rails:rails/rails",
+						"github": "rails=rails/rails",
 					},
 				},
 			},
@@ -78,7 +78,7 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 					Name:      "deployment",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"github": "rails:rails/rails,foobar:dtan4/foobar",
+						"github": "rails=rails/rails,foobar=dtan4/foobar",
 					},
 				},
 			},
@@ -105,7 +105,7 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 					Name:      "deployment",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"github": "rails:rails/rails,",
+						"github": "rails=rails/rails,",
 					},
 				},
 			},

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/pkg/api/v1"
@@ -44,6 +46,107 @@ func TestContainerImageFromDeployment(t *testing.T) {
 	for _, tc := range testcases {
 		if got := ContainerImageFromDeployment(deployment, tc.container); got != tc.expected {
 			t.Errorf("expected: %q, got: %q", tc.expected, got)
+		}
+	}
+}
+
+func TestRepositoriesFromDeployment(t *testing.T) {
+	testcases := []struct {
+		deployment *v1beta1.Deployment
+		expectErr  bool
+		expected   map[string]string
+		errMsg     string
+	}{
+		{
+			deployment: &v1beta1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Labels: map[string]string{
+						"github": "rails:rails/rails",
+					},
+				},
+			},
+			expectErr: false,
+			expected: map[string]string{
+				"rails": "rails/rails",
+			},
+		},
+		{
+			deployment: &v1beta1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Labels: map[string]string{
+						"github": "rails:rails/rails,foobar:dtan4/foobar",
+					},
+				},
+			},
+			expectErr: false,
+			expected: map[string]string{
+				"rails":  "rails/rails",
+				"foobar": "dtan4/foobar",
+			},
+		},
+		{
+			deployment: &v1beta1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Labels:    map[string]string{},
+				},
+			},
+			expectErr: true,
+			errMsg:    `label "github" not found in deployment "deployment"`,
+		},
+		{
+			deployment: &v1beta1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Labels: map[string]string{
+						"github": "rails:rails/rails,",
+					},
+				},
+			},
+			expectErr: true,
+			errMsg:    `invalid label "github" value "", must be "container=owner/repo"`,
+		},
+		{
+			deployment: &v1beta1.Deployment{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Labels: map[string]string{
+						"github": "foobarbaz",
+					},
+				},
+			},
+			expectErr: true,
+			errMsg:    `invalid label "github" value "foobarbaz", must be "container=owner/repo"`,
+		},
+	}
+
+	for _, tc := range testcases {
+		got, err := RepositoriesFromDeployment(tc.deployment)
+
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("got no error")
+				continue
+			}
+
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("got error: %s", err)
+			}
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected: %q, got: %q", tc.expected, got)
+			}
 		}
 	}
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -62,7 +62,7 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "deployment",
 					Namespace: "default",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"github": "rails:rails/rails",
 					},
 				},
@@ -77,7 +77,7 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "deployment",
 					Namespace: "default",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"github": "rails:rails/rails,foobar:dtan4/foobar",
 					},
 				},
@@ -91,39 +91,39 @@ func TestRepositoriesFromDeployment(t *testing.T) {
 		{
 			deployment: &v1beta1.Deployment{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "deployment",
-					Namespace: "default",
-					Labels:    map[string]string{},
+					Name:        "deployment",
+					Namespace:   "default",
+					Annotations: map[string]string{},
 				},
 			},
 			expectErr: true,
-			errMsg:    `label "github" not found in deployment "deployment"`,
+			errMsg:    `annotation "github" not found in Deployment "deployment"`,
 		},
 		{
 			deployment: &v1beta1.Deployment{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "deployment",
 					Namespace: "default",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"github": "rails:rails/rails,",
 					},
 				},
 			},
 			expectErr: true,
-			errMsg:    `invalid label "github" value "", must be "container=owner/repo"`,
+			errMsg:    `invalid annotation "github" value "", must be "container=owner/repo"`,
 		},
 		{
 			deployment: &v1beta1.Deployment{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "deployment",
 					Namespace: "default",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"github": "foobarbaz",
 					},
 				},
 			},
 			expectErr: true,
-			errMsg:    `invalid label "github" value "foobarbaz", must be "container=owner/repo"`,
+			errMsg:    `invalid annotation "github" value "foobarbaz", must be "container=owner/repo"`,
 		},
 	}
 


### PR DESCRIPTION
## WHY

Developers may want to deploy with just a branch name or (short) commit SHA-1. Full-qualified image name of long commit SHA-1 are hard to type.

## WHAT

Make it able to deploy with just a branch name or (long or short) commit SHA-1.

```sh-session
$ bin/k8ship ref master --namespace dtan4 -d xxx -c xxx
deploy to (deployment: "xxx", container: "xxx")
  before: 012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest
   after: 012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:e403604b21bcbbc0843199c634287704a4541dc8
```

Make it sure that apps image are built at the every time of git push. All images are tagged with its commit SHA-1.

```
012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:e403604b21bcbbc0843199c634287704a4541dc8
```

Commit SHA-1 can be acquired from branch name or short commit SHA-1 by [GitHub API](https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference). 

In addition, `github` annotation must be set in Deployment manifest.

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: app
  namespace: dtan4
  annotations:
    github: rails=012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/xxx,node=dtan4/nodejs
```