### PR TITLE
Deploy to multiple deployments at once

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,39 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// deployCmd represents the deploy command
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("deploy called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deployCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -53,13 +53,13 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(deployments) == 0 {
+	if len(targetDeployments) == 0 {
 		return errors.New("no target Deployments found")
 	}
 
 	targetContainers := map[string]*kubernetes.Container{}
 
-	for _, d := range deployments {
+	for _, d := range targetDeployments {
 		c, err := d.DeployTargetContainer()
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve deploy target container of Deployment %q", d.Name())

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -90,19 +90,19 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 
 	if deployOpts.dryRun {
 		for _, d := range targetDeployments {
-			c := targetContainers[d.Name()]
-
-			fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
-			fmt.Printf("[dry-run]  before: %s\n", c.Image())
-			fmt.Printf("[dry-run]   after: %s\n", newImage)
+			fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", d.Name(), targetContainers[d.Name()].Name())
 		}
+		fmt.Printf("[dry-run]  before: %s\n", image)
+		fmt.Printf("[dry-run]   after: %s\n", newImage)
 	} else {
 		for _, d := range targetDeployments {
-			c := targetContainers[d.Name()]
+			fmt.Printf("deploy to (deployment: %q, container: %q)\n", d.Name(), targetContainers[d.Name()].Name())
+		}
+		fmt.Printf("  before: %s\n", image)
+		fmt.Printf("   after: %s\n", newImage)
 
-			fmt.Printf("deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
-			fmt.Printf("  before: %s\n", c.Image())
-			fmt.Printf("   after: %s\n", newImage)
+		for _, d := range targetDeployments {
+			c := targetContainers[d.Name()]
 
 			if _, err := k8sClient.SetImage(d, c.Name(), newImage); err != nil {
 				return errors.Wrap(err, "failed to set image")

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -8,7 +8,13 @@ import (
 )
 
 const (
+	deployTargetAnnotation = "deploy/target"
+
 	githubAnnotation = "github"
+)
+
+var (
+	deployTargetAnnotationTrue = []string{"1", "true"}
 )
 
 // Deployment represents the wrapper of Kubernetes Deployment
@@ -48,6 +54,18 @@ func (d *Deployment) ContainerImage(container string) string {
 	}
 
 	return ""
+}
+
+// IsDeployTarget returns whether this deployment is deploy target or not
+// - has `deploy/target: 1` or `deploy/target: true` annotation
+func (d *Deployment) IsDeployTarget() bool {
+	for _, v := range deployTargetAnnotationTrue {
+		if d.raw.Annotations[deployTargetAnnotation] == v {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Labels returns the labels of Deployment

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	deployTargetAnnotation = "deploy/target"
+	deployTargetAnnotation          = "deploy/target"
+	deployTargetContainerAnnotation = "deploy/target-container"
 
 	githubAnnotation = "github"
 )
@@ -54,6 +55,23 @@ func (d *Deployment) ContainerImage(container string) string {
 	}
 
 	return ""
+}
+
+// DeployTargetContainer returns
+// - specified in `deploy/target-container` annotation
+func (d *Deployment) DeployTargetContainer() (*Container, error) {
+	v, ok := d.Annotations()[deployTargetContainerAnnotation]
+	if !ok {
+		return nil, errors.Errorf(`annotation "deploy/target-container" does not exist in Deployment %q`, d.Name())
+	}
+
+	for _, c := range d.Containers() {
+		if c.Name() == v {
+			return c, nil
+		}
+	}
+
+	return nil, errors.Errorf("container %q does not exist in Deployment %q", v, d.Name())
 }
 
 // IsDeployTarget returns whether this deployment is deploy target or not

--- a/kubernetes/deployment_test.go
+++ b/kubernetes/deployment_test.go
@@ -139,6 +139,90 @@ func TestContainerImageFromDeployment(t *testing.T) {
 	}
 }
 
+func TestIsDeployTarget(t *testing.T) {
+	testcases := []struct {
+		deployment *Deployment
+		expected   bool
+	}{
+		{
+			deployment: &Deployment{
+				raw: &v1beta1.Deployment{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "deployment",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"deploy/target": "1",
+						},
+						Labels: map[string]string{
+							"app":   "rails-app",
+							"color": "blue",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			deployment: &Deployment{
+				raw: &v1beta1.Deployment{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "deployment",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"deploy/target": "true",
+						},
+						Labels: map[string]string{
+							"app":   "rails-app",
+							"color": "blue",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			deployment: &Deployment{
+				raw: &v1beta1.Deployment{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "deployment",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"deploy/target": "false",
+						},
+						Labels: map[string]string{
+							"app":   "rails-app",
+							"color": "blue",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			deployment: &Deployment{
+				raw: &v1beta1.Deployment{
+					ObjectMeta: v1.ObjectMeta{
+						Name:        "deployment",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+						Labels: map[string]string{
+							"app":   "rails-app",
+							"color": "blue",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		if got := tc.deployment.IsDeployTarget(); got != tc.expected {
+			t.Errorf("expected: %t, got: %t", tc.expected, got)
+		}
+	}
+}
+
 func TestDeploymentLabels(t *testing.T) {
 	raw := &v1beta1.Deployment{
 		ObjectMeta: v1.ObjectMeta{

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -16,6 +16,31 @@ func DefaultNamespace() string {
 	return v1.NamespaceDefault
 }
 
+// GetTargetImage returns the unique image name of target containers
+func GetTargetImage(containers map[string]*Container) (string, error) {
+	images := map[string]bool{}
+
+	for _, c := range containers {
+		images[c.Image()] = true
+	}
+
+	ss := make([]string, 0, len(images))
+
+	for k := range images {
+		ss = append(ss, k)
+	}
+
+	if len(images) == 0 {
+		return "", errors.Errorf("no image found")
+	}
+
+	if len(images) > 1 {
+		return "", errors.Errorf("multiple images %q found, all target containers must use the same image", ss)
+	}
+
+	return ss[0], nil
+}
+
 // GetTargetRepository returns the unique GitHub repository of target containers
 func GetTargetRepository(deployments []*Deployment, containers map[string]*Container) (string, error) {
 	repos := map[string]bool{}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"github.com/pkg/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -13,4 +14,39 @@ func DefaultConfigFile() string {
 // DefaultNamespace returns the default namespace
 func DefaultNamespace() string {
 	return v1.NamespaceDefault
+}
+
+// GetTargetRepository returns the unique GitHub repository of target containers
+func GetTargetRepository(deployments []*Deployment, containers map[string]*Container) (string, error) {
+	repos := map[string]bool{}
+
+	for _, d := range deployments {
+		c, ok := containers[d.Name()]
+		if !ok {
+			return "", errors.Errorf("no container found in Deployment %q", d.Name())
+		}
+
+		rs, err := d.Repositories()
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to retrieve repositories of Deployment %q", d.Name())
+		}
+
+		v, ok := rs[c.Name()]
+		if !ok {
+			return "", errors.Errorf("GitHub repository for container %q in Deployment %q is not set", c.Name(), d.Name())
+		}
+		repos[v] = true
+	}
+
+	ss := make([]string, 0, len(repos))
+
+	for k := range repos {
+		ss = append(ss, k)
+	}
+
+	if len(repos) > 1 {
+		return "", errors.Errorf("multiple repositories %q found, all target containers must use the same repository", ss)
+	}
+
+	return ss[0], nil
 }

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -8,6 +8,94 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+func TestGetTargetImage(t *testing.T) {
+	testcases := []struct {
+		containers map[string]*Container
+		expectErr  bool
+		expected   string
+		errMsg     string
+	}{
+		{
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: false,
+			expected:  "my-rails:v3",
+		},
+		{
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+				"worker": &Container{
+					raw: &v1.Container{
+						Name:  "worker",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: false,
+			expected:  "my-rails:v3",
+		},
+		{
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+				"nginx": &Container{
+					raw: &v1.Container{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+			expectErr: true,
+			// order of repository list is random
+			// because this list is extracted from map[string]bool
+			errMsg: `all target containers must use the same image`,
+		},
+		{
+			containers: map[string]*Container{},
+			expectErr:  true,
+			errMsg:     `no image found`,
+		},
+	}
+
+	for _, tc := range testcases {
+		got, err := GetTargetImage(tc.containers)
+
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("got no error")
+				continue
+			}
+
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("got error: %s", err)
+			}
+
+			if got != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, got)
+			}
+		}
+	}
+}
+
 func TestGetTargetRepository(t *testing.T) {
 	testcases := []struct {
 		deployments []*Deployment

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -1,0 +1,220 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestGetTargetRepository(t *testing.T) {
+	testcases := []struct {
+		deployments []*Deployment
+		containers  map[string]*Container
+		expectErr   bool
+		expected    string
+		errMsg      string
+	}{
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "web",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "web=dtan4/my-rails",
+							},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: false,
+			expected:  "dtan4/my-rails",
+		},
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "web",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "web=dtan4/my-rails",
+							},
+						},
+					},
+				},
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "worker",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "worker=dtan4/my-rails",
+							},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+				"worker": &Container{
+					raw: &v1.Container{
+						Name:  "worker",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: false,
+			expected:  "dtan4/my-rails",
+		},
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:        "web",
+							Namespace:   "default",
+							Annotations: map[string]string{},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: true,
+			errMsg:    `failed to retrieve repositories of Deployment "web"`,
+		},
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "web",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "foo=dtan4/foo",
+							},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+			},
+			expectErr: true,
+			errMsg:    `GitHub repository for container "web" in Deployment "web" is not set`,
+		},
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "web",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "web=dtan4/my-rails",
+							},
+						},
+					},
+				},
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "nginx",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "nginx=dtan4/my-nginx",
+							},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+				"nginx": &Container{
+					raw: &v1.Container{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+			expectErr: true,
+			// order of repository list is random
+			// because this list is extracted from map[string]bool
+			errMsg: `all target containers must use the same repository`,
+		},
+		{
+			deployments: []*Deployment{
+				&Deployment{
+					raw: &v1beta1.Deployment{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "deployment",
+							Namespace: "default",
+							Annotations: map[string]string{
+								"github": "rails=rails/rails",
+							},
+						},
+					},
+				},
+			},
+			containers: map[string]*Container{},
+			expectErr:  true,
+			errMsg:     `no container found in Deployment "deployment"`,
+		},
+	}
+
+	for _, tc := range testcases {
+		got, err := GetTargetRepository(tc.deployments, tc.containers)
+
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("got no error")
+				continue
+			}
+
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("got error: %s", err)
+			}
+
+			if got != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## WHY

If the app has multiple roles (e.g., `web`, `worker`), we have to type `kube deploy` as many as the number of roles.

## WHAT

`kube deploy` updates all Deployments which have the below annotations:

```yaml
annotations:
  - deploy/target: "true"
  - deploy/target-container: web # or else
```