### PR TITLE
Set change cause for history

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -104,13 +104,17 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		for _, d := range targetDeployments {
 			c := targetContainers[d.Name()]
 
-			if _, err := k8sClient.SetImage(d, c.Name(), newImage); err != nil {
+			if _, err := k8sClient.SetImage(d, c.Name(), newImage, composeDeployCause(ref, deployOpts.namespace)); err != nil {
 				return errors.Wrap(err, "failed to set image")
 			}
 		}
 	}
 
 	return nil
+}
+
+func composeDeployCause(ref, namespace string) string {
+	return fmt.Sprintf(`k8ship deploy %s --namespace "%s"`, ref, namespace)
 }
 
 func init() {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -52,12 +52,18 @@ func doImage(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  before: %s\n", container.Image())
 		fmt.Printf("   after: %s\n", image)
 
-		if _, err := client.SetImage(deployment, container.Name(), image); err != nil {
+		if _, err := client.SetImage(
+			deployment, container.Name(), image, composeImageCause(image, container.Name(), deployment.Name(), tagOpts.namespace),
+		); err != nil {
 			return errors.Wrap(err, "failed to set image")
 		}
 	}
 
 	return nil
+}
+
+func composeImageCause(image, container, deployment, namespace string) string {
+	return fmt.Sprintf(`k8ship image %s --container "%s" --deployment "%s" --namespace "%s"`, image, container, deployment, namespace)
 }
 
 func init() {

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -78,12 +78,18 @@ func doRef(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  before: %s\n", container.Image())
 		fmt.Printf("   after: %s\n", newImage)
 
-		if _, err := k8sClient.SetImage(deployment, container.Name(), newImage); err != nil {
+		if _, err := k8sClient.SetImage(
+			deployment, container.Name(), newImage, composeRefCause(ref, container.Name(), deployment.Name(), refOpts.namespace),
+		); err != nil {
 			return errors.Wrap(err, "failed to set image")
 		}
 	}
 
 	return nil
+}
+
+func composeRefCause(ref, container, deployment, namespace string) string {
+	return fmt.Sprintf(`k8ship ref %s --container "%s" --deployment "%s" --namespace "%s"`, ref, container, deployment, namespace)
 }
 
 func init() {

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -56,12 +56,18 @@ func doTag(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  before: %s\n", container.Image())
 		fmt.Printf("   after: %s\n", newImage)
 
-		if _, err := client.SetImage(deployment, container.Name(), newImage); err != nil {
+		if _, err := client.SetImage(
+			deployment, container.Name(), newImage, composeTagCause(tag, container.Name(), deployment.Name(), tagOpts.namespace),
+		); err != nil {
 			return errors.Wrap(err, "failed to set image")
 		}
 	}
 
 	return nil
+}
+
+func composeTagCause(tag, container, deployment, namespace string) string {
+	return fmt.Sprintf(`k8ship tag %s --container "%s" --deployment "%s" --namespace "%s"`, tag, container, deployment, namespace)
 }
 
 func init() {

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -396,8 +396,9 @@ func TestSetImage(t *testing.T) {
 
 	container := "rails"
 	image := "my-rails:v3"
+	cause := "k8ship test"
 
-	_, err := client.SetImage(deployment, container, image)
+	_, err := client.SetImage(deployment, container, image, cause)
 	if err != nil {
 		t.Errorf("got error: %s", err)
 		return


### PR DESCRIPTION
`kubectl set image --record` sets executed command as ChangeCause. It helps us to inspect recent Deployments.

k8ship should set history too.

```sh-session
$ kubectl rollout history deployment/web -n example
deployments "web"
REVISION        CHANGE-CAUSE
1               <none>
2               <none>
3               <none>
4               <none>
6               <none>
7               <none>
8               <none>
9               <none>
12              <none>
13              <none>
20              k8ship deploy master --namespace "example"
21              k8ship deploy 26b6d790f9be7bfe362ffc92500f24844875f579 --namespace "example"
```