### PR TITLE
Deploy image and tag

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -128,7 +128,9 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		for _, d := range targetDeployments {
 			c := targetContainers[d.Name()]
 
-			if _, err := k8sClient.SetImage(d, c.Name(), newImage, composeDeployCause(deployOpts.ref, deployOpts.namespace)); err != nil {
+			if _, err := k8sClient.SetImage(
+				d, c.Name(), newImage, composeDeployCause(deployOpts.ref, deployOpts.image, deployOpts.tag, deployOpts.namespace),
+			); err != nil {
 				return errors.Wrap(err, "failed to set image")
 			}
 		}
@@ -137,8 +139,20 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func composeDeployCause(ref, namespace string) string {
-	return fmt.Sprintf(`k8ship deploy %s --namespace "%s"`, ref, namespace)
+func composeDeployCause(ref, image, tag, namespace string) string {
+	if ref != "" {
+		return fmt.Sprintf(`k8ship deploy %s --namespace "%s"`, ref, namespace)
+	}
+
+	if image != "" {
+		return fmt.Sprintf(`k8ship deploy --image %s --namespace "%s"`, image, namespace)
+	}
+
+	if tag != "" {
+		return fmt.Sprintf(`k8ship deploy --tag %s --namespace "%s"`, tag, namespace)
+	}
+
+	return ""
 }
 
 func init() {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -37,7 +37,7 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		if deployOpts.image == "" && deployOpts.tag == "" {
 			return errors.New("target image (--image) or tag (--tag) must be specified")
 		}
-	} else if len(args) != 1 {
+	} else if len(args) == 1 {
 		deployOpts.ref = args[0]
 	} else {
 		return errors.New("--image, --tag, or ref (branch, full commit SHA-1 or short commit SHA-1) must be given")


### PR DESCRIPTION
Add `--image` and `--tag` flags to `k8ship deploy`. It enables users to deploy a specific image or tag to multiple Deployments at once.