### PR TITLE
Add annotation prefix

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -43,7 +43,7 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		return errors.New("--image, --tag, or ref (branch, full commit SHA-1 or short commit SHA-1) must be given")
 	}
 
-	k8sClient, err := kubernetes.NewClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sClient, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -28,7 +28,7 @@ func doImage(cmd *cobra.Command, args []string) error {
 	}
 	image := args[0]
 
-	client, err := kubernetes.NewClient(rootOpts.kubeconfig, rootOpts.context)
+	client, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -33,7 +33,7 @@ func doRef(cmd *cobra.Command, args []string) error {
 	}
 	ref := args[0]
 
-	k8sClient, err := kubernetes.NewClient(rootOpts.kubeconfig, rootOpts.context)
+	k8sClient, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,9 @@ var RootCmd = &cobra.Command{
 }
 
 var rootOpts = struct {
-	context    string
-	kubeconfig string
+	annotationPrefix string
+	context          string
+	kubeconfig       string
 }{}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -33,12 +34,17 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	RootCmd.PersistentFlags().StringVar(&rootOpts.annotationPrefix, "annotation-prefix", "", "annotation prefix")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.context, "context", "", "Kubernetes context")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.kubeconfig, "kubeconfig", "", "kubeconfig path")
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	if rootOpts.annotationPrefix == "" {
+		rootOpts.annotationPrefix = os.Getenv("K8SHIP_ANNOTATION_PREFIX")
+	}
+
 	if rootOpts.kubeconfig == "" {
 		if os.Getenv("KUBECONFIG") == "" {
 			rootOpts.kubeconfig = kubernetes.DefaultConfigFile()

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -29,7 +29,7 @@ func doTag(cmd *cobra.Command, args []string) error {
 	}
 	tag := args[0]
 
-	client, err := kubernetes.NewClient(rootOpts.kubeconfig, rootOpts.context)
+	client, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}


### PR DESCRIPTION
## WHY

Kubernetes uses annotation prefix (e.g., `kubernetes.io/ingress.global-static-ip-name`) fot rheir reserved annotations/labels name. We can distinguish those as reserved labels at a glance.

`deploy/target`, `github` are so common names. We can't find whether those are Kubernetes' field or not.

## WHAT

Add `--annotation-prefix` flag and `K8SHIP_ANNOTATION_PREFIX` env to specify annotation prefix.

```
k8ship deploy --annotation-prefix dtan4.io/
```

finds

- `dtan4.io/deploy/target`
- `dtan4.io/deploy/target-container`
- `dtan4.io/github`

annotations.