### PR TITLE
Remove / from annotation base

### DIFF
--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	deployTargetAnnotation          = "deploy/target"
-	deployTargetContainerAnnotation = "deploy/target-container"
+	deployTargetAnnotation          = "deploy-target"
+	deployTargetContainerAnnotation = "deploy-target-container"
 
 	githubAnnotation = "github"
 )
@@ -60,11 +60,11 @@ func (d *Deployment) ContainerImage(container string) string {
 }
 
 // DeployTargetContainer returns
-// - specified in `deploy/target-container` annotation
+// - specified in `deploy-target-container` annotation
 func (d *Deployment) DeployTargetContainer() (*Container, error) {
 	v, ok := d.Annotations()[d.annotationPrefix+deployTargetContainerAnnotation]
 	if !ok {
-		return nil, errors.Errorf(`annotation "deploy/target-container" does not exist in Deployment %q`, d.Name())
+		return nil, errors.Errorf(`annotation "deploy-target-container" does not exist in Deployment %q`, d.Name())
 	}
 
 	for _, c := range d.Containers() {
@@ -77,7 +77,7 @@ func (d *Deployment) DeployTargetContainer() (*Container, error) {
 }
 
 // IsDeployTarget returns whether this deployment is deploy target or not
-// - has `deploy/target: 1` or `deploy/target: true` annotation
+// - has `deploy-target: 1` or `deploy-target: true` annotation
 func (d *Deployment) IsDeployTarget() bool {
 	for _, v := range deployTargetAnnotationTrue {
 		if d.raw.Annotations[d.annotationPrefix+deployTargetAnnotation] == v {

--- a/kubernetes/deployment_test.go
+++ b/kubernetes/deployment_test.go
@@ -15,8 +15,8 @@ func TestDeploymentAnnotations(t *testing.T) {
 			Name:      "deployment",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"deploy/target":           "1",
-				"deploy/target-container": "rails",
+				"deploy-target":           "1",
+				"deploy-target-container": "rails",
 				"github":                  "dtan4/rails-app",
 			},
 			Labels: map[string]string{
@@ -42,8 +42,8 @@ func TestDeploymentAnnotations(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"deploy/target":           "1",
-		"deploy/target-container": "rails",
+		"deploy-target":           "1",
+		"deploy-target-container": "rails",
 		"github":                  "dtan4/rails-app",
 	}
 	if got := deployment.Annotations(); !reflect.DeepEqual(got, expected) {
@@ -57,8 +57,8 @@ func TestDeploymentContainers(t *testing.T) {
 			Name:      "deployment",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"deploy/target":           "1",
-				"deploy/target-container": "rails",
+				"deploy-target":           "1",
+				"deploy-target-container": "rails",
 				"github":                  "dtan4/rails-app",
 			},
 			Labels: map[string]string{
@@ -153,8 +153,8 @@ func TestDeployTargetContainer(t *testing.T) {
 						Name:      "deployment",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"deploy/target":           "1",
-							"deploy/target-container": "rails",
+							"deploy-target":           "1",
+							"deploy-target-container": "rails",
 						},
 					},
 					Spec: v1beta1.DeploymentSpec{
@@ -181,8 +181,8 @@ func TestDeployTargetContainer(t *testing.T) {
 						Name:      "deployment",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"deploy/target":           "1",
-							"deploy/target-container": "nginx",
+							"deploy-target":           "1",
+							"deploy-target-container": "nginx",
 						},
 					},
 					Spec: v1beta1.DeploymentSpec{
@@ -225,7 +225,7 @@ func TestDeployTargetContainer(t *testing.T) {
 				},
 			},
 			expectErr: true,
-			errMsg:    `annotation "deploy/target-container" does not exist in Deployment "deployment"`,
+			errMsg:    `annotation "deploy-target-container" does not exist in Deployment "deployment"`,
 		},
 	}
 
@@ -265,7 +265,7 @@ func TestIsDeployTarget(t *testing.T) {
 						Name:      "deployment",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"deploy/target": "1",
+							"deploy-target": "1",
 						},
 						Labels: map[string]string{
 							"app":   "rails-app",
@@ -283,7 +283,7 @@ func TestIsDeployTarget(t *testing.T) {
 						Name:      "deployment",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"deploy/target": "true",
+							"deploy-target": "true",
 						},
 						Labels: map[string]string{
 							"app":   "rails-app",
@@ -301,7 +301,7 @@ func TestIsDeployTarget(t *testing.T) {
 						Name:      "deployment",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"deploy/target": "false",
+							"deploy-target": "false",
 						},
 						Labels: map[string]string{
 							"app":   "rails-app",
@@ -343,8 +343,8 @@ func TestDeploymentLabels(t *testing.T) {
 			Name:      "deployment",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"deploy/target":           "1",
-				"deploy/target-container": "rails",
+				"deploy-target":           "1",
+				"deploy-target-container": "rails",
 				"github":                  "dtan4/rails-app",
 			},
 			Labels: map[string]string{
@@ -384,8 +384,8 @@ func TestDeploymentName(t *testing.T) {
 			Name:      "deployment",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"deploy/target":           "1",
-				"deploy/target-container": "rails",
+				"deploy-target":           "1",
+				"deploy-target-container": "rails",
 				"github":                  "dtan4/rails-app",
 			},
 			Labels: map[string]string{
@@ -422,8 +422,8 @@ func TestDeploymentNamespace(t *testing.T) {
 			Name:      "deployment",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"deploy/target":           "1",
-				"deploy/target-container": "rails",
+				"deploy-target":           "1",
+				"deploy-target-container": "rails",
 				"github":                  "dtan4/rails-app",
 			},
 			Labels: map[string]string{


### PR DESCRIPTION
## WHY

Annotation name `example.com/deploy/target` is invalid. 

> with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')

## WHAT

Remove `/` from annotation name base