### PR TITLE
Allow different tag at `k8ship deploy`

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/dtan4/k8ship/github"
 	"github.com/dtan4/k8ship/kubernetes"
@@ -98,7 +97,7 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		}
 
 		if deployOpts.tag != "" {
-			newImage = strings.Split(image, ":")[0] + ":" + deployOpts.tag
+			newImage = image + ":" + deployOpts.tag
 		}
 	} else {
 		ctx := context.Background()
@@ -109,21 +108,23 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "failed to retrieve commit SHA-1 matched to ref %q in repo %q", deployOpts.ref, repo)
 		}
 
-		newImage = strings.Split(image, ":")[0] + ":" + sha1
+		newImage = image + ":" + sha1
 	}
 
 	if deployOpts.dryRun {
 		for _, d := range targetDeployments {
-			fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", d.Name(), targetContainers[d.Name()].Name())
+			c := targetContainers[d.Name()]
+			fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
+			fmt.Printf("[dry-run]  before: %s\n", c.Image())
+			fmt.Printf("[dry-run]   after: %s\n", newImage)
 		}
-		fmt.Printf("[dry-run]  before: %s\n", image)
-		fmt.Printf("[dry-run]   after: %s\n", newImage)
 	} else {
 		for _, d := range targetDeployments {
-			fmt.Printf("deploy to (deployment: %q, container: %q)\n", d.Name(), targetContainers[d.Name()].Name())
+			c := targetContainers[d.Name()]
+			fmt.Printf("deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
+			fmt.Printf("  before: %s\n", c.Image())
+			fmt.Printf("   after: %s\n", newImage)
 		}
-		fmt.Printf("  before: %s\n", image)
-		fmt.Printf("   after: %s\n", newImage)
 
 		for _, d := range targetDeployments {
 			c := targetContainers[d.Name()]

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -115,15 +115,15 @@ func doDeploy(cmd *cobra.Command, args []string) error {
 		for _, d := range targetDeployments {
 			c := targetContainers[d.Name()]
 			fmt.Printf("[dry-run] deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
-			fmt.Printf("[dry-run]  before: %s\n", c.Image())
-			fmt.Printf("[dry-run]   after: %s\n", newImage)
+			fmt.Printf("[dry-run]   before: %s\n", c.Image())
+			fmt.Printf("[dry-run]   after:  %s\n", newImage)
 		}
 	} else {
 		for _, d := range targetDeployments {
 			c := targetContainers[d.Name()]
 			fmt.Printf("deploy to (deployment: %q, container: %q)\n", d.Name(), c.Name())
 			fmt.Printf("  before: %s\n", c.Image())
-			fmt.Printf("   after: %s\n", newImage)
+			fmt.Printf("  after:  %s\n", newImage)
 		}
 
 		for _, d := range targetDeployments {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -21,7 +23,7 @@ func GetTargetImage(containers map[string]*Container) (string, error) {
 	images := map[string]bool{}
 
 	for _, c := range containers {
-		images[c.Image()] = true
+		images[strings.Split(c.Image(), ":")[0]] = true
 	}
 
 	ss := make([]string, 0, len(images))

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -25,7 +25,7 @@ func TestGetTargetImage(t *testing.T) {
 				},
 			},
 			expectErr: false,
-			expected:  "my-rails:v3",
+			expected:  "my-rails",
 		},
 		{
 			containers: map[string]*Container{
@@ -43,7 +43,25 @@ func TestGetTargetImage(t *testing.T) {
 				},
 			},
 			expectErr: false,
-			expected:  "my-rails:v3",
+			expected:  "my-rails",
+		},
+		{
+			containers: map[string]*Container{
+				"web": &Container{
+					raw: &v1.Container{
+						Name:  "web",
+						Image: "my-rails:v3",
+					},
+				},
+				"worker": &Container{
+					raw: &v1.Container{
+						Name:  "worker",
+						Image: "my-rails:abc123",
+					},
+				},
+			},
+			expectErr: false,
+			expected:  "my-rails",
 		},
 		{
 			containers: map[string]*Container{


### PR DESCRIPTION
Current `k8ship deploy` requires that all target Deployments must have the same image name and tag.
If image tags are different (e.g., `latest` and `4b7b5c831ba1507f38fa4b86e74e91eec61c62d1`), `deploy` command will fail.

However, in most cases we can deploy the same image to all target Deployments if the image names are the same.
For example,

- `app:latest` and `nginx:1.10.3` cannot be replaced to `app:0e474de1015afaa81690f250a85f16fb5de83d3a`
  - these Deployments do not refer the same application
- `app:latest` and `app:4b7b5c831ba1507f38fa4b86e74e91eec61c62d1` can be replaced to `app:0e474de1015afaa81690f250a85f16fb5de83d3a`
  - these Deployments refer the same applications (in most cases)

By this change, we can deploy the same image even if target image tags are different.