### PR TITLE
Reload all Pods in Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ $ k8ship ref topic/foo -d app
 
 This command does the same as the above.
 
+### `k8ship reload`
+
+Reload all Pods in Deployment.
+
+The below command reload = redeploys Pods in the target Deployment, in manner of rolling deployment.
+
+```sh-session
+$ k8ship reload
+```
+
 ### `k8ship tag`
 
 Deploy with Docker image tag.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ The below command reload = redeploys Pods in the target Deployment, in manner of
 $ k8ship reload
 ```
 
+To reload ALL Deployments:
+
+```sh-session
+$ k8ship reload --all
+```
+
+To reload Deployment `web`:
+
+```sh-session
+$ k8ship reload -d web
+```
+
 ### `k8ship tag`
 
 Deploy with Docker image tag.

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -1,0 +1,39 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// reloadCmd represents the reload command
+var reloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("reload called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(reloadCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// reloadCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// reloadCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -16,36 +16,42 @@ var reloadCmd = &cobra.Command{
 	RunE:  doReload,
 }
 
+var reloadOpts = struct {
+	deployment string
+	namespace  string
+}{}
+
 func doReload(cmd *cobra.Command, args []string) error {
 	k8sClient, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}
 
-	deployments, err := k8sClient.ListDeployments(deployOpts.namespace)
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve Deployments")
-	}
+	var deployments []*kubernetes.Deployment
 
-	if len(deployments) == 0 {
-		return errors.Errorf("no Deployment found in namespace %s", deployOpts.namespace)
-	}
-
-	targetDeployments := []*kubernetes.Deployment{}
-
-	for _, d := range deployments {
-		if d.IsDeployTarget() {
-			targetDeployments = append(targetDeployments, d)
+	if reloadOpts.deployment == "" {
+		ds, err := k8sClient.ListDeployments(reloadOpts.namespace)
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve Deployments")
 		}
-	}
 
-	if len(targetDeployments) == 0 {
-		return errors.New("no target Deployments found")
+		if len(ds) == 0 {
+			return errors.Errorf("no Deployment found in namespace %s", reloadOpts.namespace)
+		}
+
+		deployments = ds
+	} else {
+		d, err := k8sClient.GetDeployment(reloadOpts.namespace, reloadOpts.deployment)
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve Deployment %s in %s", reloadOpts.deployment, reloadOpts.namespace)
+		}
+
+		deployments = []*kubernetes.Deployment{d}
 	}
 
 	timestamp := time.Now().Local().String()
 
-	for _, d := range targetDeployments {
+	for _, d := range deployments {
 		_, err := k8sClient.ReloadPods(d, timestamp)
 		if err != nil {
 			return errors.Wrap(err, "failed to set annotations")
@@ -59,4 +65,7 @@ func doReload(cmd *cobra.Command, args []string) error {
 
 func init() {
 	RootCmd.AddCommand(reloadCmd)
+
+	reloadCmd.Flags().StringVarP(&reloadOpts.deployment, "deployment", "d", "", "target Deployment")
+	reloadCmd.Flags().StringVarP(&reloadOpts.namespace, "namespace", "n", kubernetes.DefaultNamespace(), "Kubernetes namespace")
 }

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -46,9 +46,7 @@ func doReload(cmd *cobra.Command, args []string) error {
 	timestamp := time.Now().Local().String()
 
 	for _, d := range targetDeployments {
-		_, err := k8sClient.SetAnnotations(d, map[string]string{
-			"reloaded-at": timestamp,
-		})
+		_, err := k8sClient.ReloadPods(d, timestamp)
 		if err != nil {
 			return errors.Wrap(err, "failed to set annotations")
 		}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -161,8 +161,10 @@ func (c *Client) SetAnnotations(deployment *Deployment, annotations map[string]s
 
 	patch := fmt.Sprintf(`{
   "spec": {
-    "metadata": {
-      "annotations": %s,
+    "template": {
+      "metadata": {
+        "annotations": %s
+      }
     }
   }
 }`, string(j))

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -366,6 +366,47 @@ func TestListDeployments(t *testing.T) {
 	}
 }
 
+func TestSetAnnotations(t *testing.T) {
+	raw := &v1beta1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "deployment",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  "rails",
+							Image: "my-rails:v2",
+						},
+					},
+				},
+			},
+		},
+	}
+	deployment := &Deployment{
+		raw: raw,
+	}
+
+	clientset := fake.NewSimpleClientset(raw)
+	client := &Client{
+		clientset: clientset,
+	}
+
+	annotations := map[string]string{
+		"foo": "BAR",
+	}
+
+	_, err := client.SetAnnotations(deployment, annotations)
+	if err != nil {
+		t.Errorf("got error: %s", err)
+		return
+	}
+
+	// Unfortunally, there is no way to check the updated Deployment image...
+}
+
 func TestSetImage(t *testing.T) {
 	raw := &v1beta1.Deployment{
 		ObjectMeta: v1.ObjectMeta{

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -366,7 +366,7 @@ func TestListDeployments(t *testing.T) {
 	}
 }
 
-func TestSetAnnotations(t *testing.T) {
+func TestReloadPods(t *testing.T) {
 	raw := &v1beta1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "deployment",
@@ -394,11 +394,9 @@ func TestSetAnnotations(t *testing.T) {
 		clientset: clientset,
 	}
 
-	annotations := map[string]string{
-		"foo": "BAR",
-	}
+	signature := "2017-12-05 12:18:31.789275051 +0900 JST"
 
-	_, err := client.SetAnnotations(deployment, annotations)
+	_, err := client.ReloadPods(deployment, signature)
 	if err != nil {
 		t.Errorf("got error: %s", err)
 		return


### PR DESCRIPTION
## Why

After setting secrets or configmap, we have to recreate Pods to reflect these changes. This can be achieved by setting dummy key-value in Deployment `spec.metadata.{labels,annotations}`.

## What

Add new `k8ship reload` command to reload all Pods in the target Deployment.
This command adds `<prefix>reloaded-at: <timestamp>` Pod annotation to Deployment manifest.