### PR TITLE
Add `k8ship history` command

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -12,6 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultHistoryLimit = 10
+)
+
 // historyCmd represents the history command
 var historyCmd = &cobra.Command{
 	Use:   "history",
@@ -20,6 +24,7 @@ var historyCmd = &cobra.Command{
 }
 
 var historyOpts = struct {
+	all       bool
 	namespace string
 }{}
 
@@ -72,6 +77,10 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		lines := formatHistory(rs, tcs[d.Name()])
 		sort.Sort(sort.Reverse(sort.StringSlice(lines)))
 
+		if !historyOpts.all {
+			lines = lines[0:defaultHistoryLimit]
+		}
+
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		headers := []string{
 			"DEPLOYED AT",
@@ -105,5 +114,6 @@ func formatHistory(rs []*kubernetes.ReplicaSet, container *kubernetes.Container)
 func init() {
 	RootCmd.AddCommand(historyCmd)
 
+	historyCmd.Flags().BoolVarP(&historyOpts.all, "all", "a", false, fmt.Sprintf("Print all relases (default: recent %d items)", defaultHistoryLimit))
 	historyCmd.Flags().StringVarP(&historyOpts.namespace, "namespace", "n", kubernetes.DefaultNamespace(), "Kubernetes namespace")
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/dtan4/k8ship/kubernetes"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -11,10 +15,43 @@ var historyCmd = &cobra.Command{
 	RunE:  doHistory,
 }
 
+var historyOpts = struct {
+	namespace string
+}{}
+
 func doHistory(cmd *cobra.Command, args []string) error {
+	client, err := kubernetes.NewClient(rootOpts.annotationPrefix, rootOpts.kubeconfig, rootOpts.context)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Kubernetes client")
+	}
+
+	ds, err := client.ListDeployments(historyOpts.namespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve Deployments")
+	}
+
+	if len(ds) == 0 {
+		return errors.Errorf("no Deployment found in namespace %s", historyOpts.namespace)
+	}
+
+	for _, d := range ds {
+		fmt.Println("===== " + d.Name())
+
+		rs, err := client.ListReplicaSets(d)
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve ReplicaSets")
+		}
+
+		for _, r := range rs {
+			fmt.Printf("%s %s %s\n", r.Revision(), r.Name(), r.CreatedAt())
+		}
+	}
+
 	return nil
 }
 
 func init() {
 	RootCmd.AddCommand(historyCmd)
+
+	historyCmd.Flags().StringVarP(&historyOpts.namespace, "namespace", "n", kubernetes.DefaultNamespace(), "Kubernetes namespace")
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -74,7 +74,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		headers := []string{
-			"CREATED AT",
+			"DEPLOYED AT",
 			"REVISION",
 			"DEPLOYED IMAGE",
 		}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/dtan4/k8ship/kubernetes"
 	"github.com/pkg/errors"
@@ -42,12 +43,25 @@ func doHistory(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to retrieve ReplicaSets")
 		}
 
-		for _, r := range rs {
-			fmt.Printf("%s %s %s %s\n", r.Revision(), r.Name(), r.CreatedAt(), r.Images())
+		lines := formatHistory(rs)
+		sort.Sort(sort.Reverse(sort.StringSlice(lines)))
+
+		for _, l := range lines {
+			fmt.Println(l)
 		}
 	}
 
 	return nil
+}
+
+func formatHistory(rs []*kubernetes.ReplicaSet) []string {
+	lines := make([]string, 0, len(rs))
+
+	for _, r := range rs {
+		lines = append(lines, fmt.Sprintf("%s %s %s", r.CreatedAt(), r.Revision(), r.Images()))
+	}
+
+	return lines
 }
 
 func init() {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -1,39 +1,20 @@
-// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
-
-
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 // historyCmd represents the history command
 var historyCmd = &cobra.Command{
 	Use:   "history",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "View deployment history",
+	RunE:  doHistory,
+}
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("history called")
-	},
+func doHistory(cmd *cobra.Command, args []string) error {
+	return nil
 }
 
 func init() {
 	RootCmd.AddCommand(historyCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// historyCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// historyCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -62,7 +62,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, d := range tds {
-		fmt.Println("===== " + d.Name())
+		fmt.Println("===== " + d.Name() + " =====")
 
 		rs, err := client.ListReplicaSets(d)
 		if err != nil {
@@ -85,6 +85,8 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		}
 
 		w.Flush()
+
+		fmt.Printf("\n")
 	}
 
 	return nil

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/dtan4/k8ship/kubernetes"
 	"github.com/pkg/errors"
@@ -46,9 +49,18 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		lines := formatHistory(rs)
 		sort.Sort(sort.Reverse(sort.StringSlice(lines)))
 
-		for _, l := range lines {
-			fmt.Println(l)
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		headers := []string{
+			"CREATED AT",
+			"IMAGES",
 		}
+		fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+		for _, l := range lines {
+			fmt.Fprintln(w, l)
+		}
+
+		w.Flush()
 	}
 
 	return nil
@@ -58,7 +70,7 @@ func formatHistory(rs []*kubernetes.ReplicaSet) []string {
 	lines := make([]string, 0, len(rs))
 
 	for _, r := range rs {
-		lines = append(lines, fmt.Sprintf("%s %s", r.CreatedAt(), r.Images()))
+		lines = append(lines, fmt.Sprintf("%s\t%s", r.CreatedAt(), r.Images()))
 	}
 
 	return lines

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -75,6 +75,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		headers := []string{
 			"CREATED AT",
+			"REVISION",
 			"DEPLOYED IMAGE",
 		}
 		fmt.Fprintln(w, strings.Join(headers, "\t"))
@@ -93,7 +94,7 @@ func formatHistory(rs []*kubernetes.ReplicaSet, container *kubernetes.Container)
 	lines := make([]string, 0, len(rs))
 
 	for _, r := range rs {
-		lines = append(lines, fmt.Sprintf("%s\t%s", r.CreatedAt(), r.Images()[container.Name()]))
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%s", r.CreatedAt(), r.Revision(), r.Images()[container.Name()]))
 	}
 
 	return lines

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -1,0 +1,39 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// historyCmd represents the history command
+var historyCmd = &cobra.Command{
+	Use:   "history",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("history called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(historyCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// historyCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// historyCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -70,10 +70,20 @@ func formatHistory(rs []*kubernetes.ReplicaSet) []string {
 	lines := make([]string, 0, len(rs))
 
 	for _, r := range rs {
-		lines = append(lines, fmt.Sprintf("%s\t%s", r.CreatedAt(), r.Images()))
+		lines = append(lines, fmt.Sprintf("%s\t%s", r.CreatedAt(), formatImages(r.Images())))
 	}
 
 	return lines
+}
+
+func formatImages(images map[string]string) string {
+	ss := make([]string, 0, len(images))
+
+	for k, v := range images {
+		ss = append(ss, k+" => "+v)
+	}
+
+	return strings.Join(ss, ",")
 }
 
 func init() {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -43,7 +43,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, r := range rs {
-			fmt.Printf("%s %s %s\n", r.Revision(), r.Name(), r.CreatedAt())
+			fmt.Printf("%s %s %s %s\n", r.Revision(), r.Name(), r.CreatedAt(), r.Images())
 		}
 	}
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -58,7 +58,7 @@ func formatHistory(rs []*kubernetes.ReplicaSet) []string {
 	lines := make([]string, 0, len(rs))
 
 	for _, r := range rs {
-		lines = append(lines, fmt.Sprintf("%s %s %s", r.CreatedAt(), r.Revision(), r.Images()))
+		lines = append(lines, fmt.Sprintf("%s %s", r.CreatedAt(), r.Images()))
 	}
 
 	return lines

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -151,6 +151,26 @@ func (c *Client) ListDeployments(namespace string) ([]*Deployment, error) {
 	return ds, nil
 }
 
+// ListReplicaSets returns the list of ReplicaSets
+func (c *Client) ListReplicaSets(deployment *Deployment) ([]string, error) {
+	all, err := c.clientset.ExtensionsV1beta1().ReplicaSets(deployment.Namespace()).List(v1.ListOptions{})
+	if err != nil {
+		return []string{}, errors.Wrapf(err, "failed to retrieve ReplicaSets")
+	}
+
+	filtered := make([]string, 0, len(all.Items))
+
+	for _, rs := range all.Items {
+		for _, or := range rs.GetOwnerReferences() {
+			if string(or.UID) == deployment.UID() {
+				filtered = append(filtered, rs.Name)
+			}
+		}
+	}
+
+	return filtered, nil
+}
+
 // ReloadPods reloads all Pods in the given deployment by setting new annotation
 func (c *Client) ReloadPods(deployment *Deployment, signature string) (*Deployment, error) {
 	patch := fmt.Sprintf(`{

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -163,7 +163,8 @@ func (c *Client) ListReplicaSets(deployment *Deployment) ([]*ReplicaSet, error) 
 	for _, rs := range all.Items {
 		for _, or := range rs.GetOwnerReferences() {
 			if string(or.UID) == deployment.UID() {
-				filtered = append(filtered, NewReplicaSet(&rs))
+				r := rs
+				filtered = append(filtered, NewReplicaSet(&r))
 			}
 		}
 	}

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -152,18 +152,18 @@ func (c *Client) ListDeployments(namespace string) ([]*Deployment, error) {
 }
 
 // ListReplicaSets returns the list of ReplicaSets
-func (c *Client) ListReplicaSets(deployment *Deployment) ([]string, error) {
+func (c *Client) ListReplicaSets(deployment *Deployment) ([]*ReplicaSet, error) {
 	all, err := c.clientset.ExtensionsV1beta1().ReplicaSets(deployment.Namespace()).List(v1.ListOptions{})
 	if err != nil {
-		return []string{}, errors.Wrapf(err, "failed to retrieve ReplicaSets")
+		return []*ReplicaSet{}, errors.Wrapf(err, "failed to retrieve ReplicaSets")
 	}
 
-	filtered := make([]string, 0, len(all.Items))
+	filtered := make([]*ReplicaSet, 0, len(all.Items))
 
 	for _, rs := range all.Items {
 		for _, or := range rs.GetOwnerReferences() {
 			if string(or.UID) == deployment.UID() {
-				filtered = append(filtered, rs.Name)
+				filtered = append(filtered, NewReplicaSet(&rs))
 			}
 		}
 	}

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -432,8 +432,8 @@ func TestListReplicaSets(t *testing.T) {
 	}
 
 	expectedName := "deployment-1234567890"
-	if got[0] != expectedName {
-		t.Errorf("expected: %q, got: %q", expectedName, got[0])
+	if got[0].Name() != expectedName {
+		t.Errorf("expected: %q, got: %q", expectedName, got[0].Name())
 	}
 }
 

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -122,3 +122,8 @@ func (d *Deployment) Repositories() (map[string]string, error) {
 
 	return repos, nil
 }
+
+// UID returns the UID of Deployment
+func (d *Deployment) UID() string {
+	return string(d.raw.UID)
+}

--- a/kubernetes/replica_set.go
+++ b/kubernetes/replica_set.go
@@ -27,6 +27,17 @@ func (r *ReplicaSet) CreatedAt() time.Time {
 	return r.raw.CreationTimestamp.Time
 }
 
+// Images returns the list of deployed images at the moment
+func (r *ReplicaSet) Images() map[string]string {
+	images := map[string]string{}
+
+	for _, c := range r.raw.Spec.Template.Spec.Containers {
+		images[c.Name] = c.Image
+	}
+
+	return images
+}
+
 // Name returns the name of ReplicaSet
 func (r *ReplicaSet) Name() string {
 	return r.raw.Name

--- a/kubernetes/replica_set.go
+++ b/kubernetes/replica_set.go
@@ -1,7 +1,13 @@
 package kubernetes
 
 import (
+	"time"
+
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+const (
+	revisionAnnotation = "deployment.kubernetes.io/revision"
 )
 
 // ReplicaSet represents the wrapper of Kubernetes ReplicaSet
@@ -16,6 +22,11 @@ func NewReplicaSet(raw *v1beta1.ReplicaSet) *ReplicaSet {
 	}
 }
 
+// CreatedAt returns the creation timestamp
+func (r *ReplicaSet) CreatedAt() time.Time {
+	return r.raw.CreationTimestamp.Time
+}
+
 // Name returns the name of ReplicaSet
 func (r *ReplicaSet) Name() string {
 	return r.raw.Name
@@ -24,4 +35,9 @@ func (r *ReplicaSet) Name() string {
 // Namespace returns the namespace of ReplicaSet
 func (r *ReplicaSet) Namespace() string {
 	return r.raw.Namespace
+}
+
+// Revision returns the revision signature
+func (r *ReplicaSet) Revision() string {
+	return r.raw.Annotations[revisionAnnotation]
 }

--- a/kubernetes/replica_set.go
+++ b/kubernetes/replica_set.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// ReplicaSet represents the wrapper of Kubernetes ReplicaSet
+type ReplicaSet struct {
+	raw *v1beta1.ReplicaSet
+}
+
+// NewReplicaSet creates ne ReplicaSet object
+func NewReplicaSet(raw *v1beta1.ReplicaSet) *ReplicaSet {
+	return &ReplicaSet{
+		raw: raw,
+	}
+}
+
+// Name returns the name of ReplicaSet
+func (r *ReplicaSet) Name() string {
+	return r.raw.Name
+}
+
+// Namespace returns the namespace of ReplicaSet
+func (r *ReplicaSet) Namespace() string {
+	return r.raw.Namespace
+}

--- a/kubernetes/replica_set_test.go
+++ b/kubernetes/replica_set_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -27,6 +28,43 @@ func TestCreatedAt(t *testing.T) {
 	want := time.Date(2017, 12, 14, 16, 36, 17, 0, time.UTC)
 	if !got.Equal(want) {
 		t.Errorf("want: %v, got: %v", want, got)
+	}
+}
+
+func TestImages(t *testing.T) {
+	raw := &v1beta1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "deployment-1234567890",
+			Namespace: "default",
+		},
+		Spec: v1beta1.ReplicaSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  "web",
+							Image: "web:v1",
+						},
+						v1.Container{
+							Name:  "nginx",
+							Image: "nginx:1.13.7",
+						},
+					},
+				},
+			},
+		},
+	}
+	r := &ReplicaSet{
+		raw: raw,
+	}
+
+	got := r.Images()
+	want := map[string]string{
+		"web":   "web:v1",
+		"nginx": "nginx:1.13.7",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want: %#v, got: %#v", want, got)
 	}
 }
 

--- a/kubernetes/replica_set_test.go
+++ b/kubernetes/replica_set_test.go
@@ -1,0 +1,52 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestCreatedAt(t *testing.T) {
+	raw := &v1beta1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "deployment-1234567890",
+			Namespace: "default",
+			CreationTimestamp: unversioned.Time{
+				Time: time.Date(2017, 12, 14, 16, 36, 17, 0, time.UTC),
+			},
+		},
+	}
+	r := &ReplicaSet{
+		raw: raw,
+	}
+
+	got := r.CreatedAt()
+	want := time.Date(2017, 12, 14, 16, 36, 17, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("want: %v, got: %v", want, got)
+	}
+}
+
+func TestRevision(t *testing.T) {
+	raw := &v1beta1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+			Name:      "deployment-1234567890",
+			Namespace: "default",
+		},
+	}
+	r := &ReplicaSet{
+		raw: raw,
+	}
+
+	got := r.Revision()
+	want := "1"
+	if got != want {
+		t.Errorf("want: %q, got: %q", want, got)
+	}
+}


### PR DESCRIPTION
## Why

`kubectl rollout history deploy/xxx` provides the recent deploy history.

```sh-session
$ kubectl rollout history deploy/web -n awesome-app
deployments "web"
REVISION  CHANGE-CAUSE
1         <none>
2         <none>
3         <none>
...
220       kubectl set image deployment/web web=dtan4/awesome-app:48ac909e7df23af5793979eb5c2a9eea0e0fefc0 --record=true
222       kubectl set image deployment/web web=dtan4/awesome-app:c752436850c05c2c96e3c3373ed9c671c774fd01 --record=true
224       kubectl set image deployment/web web=dtan4/awesome-app:7a611fdb41f788dc4f82f8e4aa773f87e5ebd2d5 --record=true
```

However, this output lacks some fields...

- When the deployment was made?
- Who deployed the revision?
- What revision was deployed?

## What

Add `k8ship history` command to display recent deployments in table view.

```sh-session
$ bin/k8ship history -n awesome-app
===== web =====
DEPLOYED AT                    REVISION  DEPLOYED IMAGE
2017-12-17 13:49:55 +0900 JST  224       dtan4/awesome-app:7a611fdb41f788dc4f82f8e4aa773f87e5ebd2d5
2017-12-17 13:25:50 +0900 JST  223       dtan4/awesome-app:2005227e9187af26472073df276faaf332e15062
2017-12-15 20:28:08 +0900 JST  222       dtan4/awesome-app:c752436850c05c2c96e3c3373ed9c671c774fd01
2017-12-15 19:16:38 +0900 JST  221       dtan4/awesome-app:b743581f7c00824f341116ad5d28ad6e6d06cb50
2017-12-15 17:25:12 +0900 JST  220       dtan4/awesome-app:48ac909e7df23af5793979eb5c2a9eea0e0fefc0
2017-12-15 15:09:53 +0900 JST  219       dtan4/awesome-app:f238baadf3a243c8829ddce4ab13232582728ec7
2017-12-15 11:50:04 +0900 JST  218       dtan4/awesome-app:db4cba4bce76e88c2759e34913f46fbb3b2217a4
2017-12-14 18:19:34 +0900 JST  217       dtan4/awesome-app:0550e21decf1d7af4bae256b380b8ebf630520c4
2017-12-13 16:12:55 +0900 JST  216       dtan4/awesome-app:a7c26cd85a71c629c25e4ccd9441e69fb5b70bb2
2017-12-13 13:42:36 +0900 JST  215       dtan4/awesome-app:e0c2f581ede3f66a6eefb7ef126a08d70733b624

===== worker =====
DEPLOYED AT                    REVISION  DEPLOYED IMAGE
2017-12-17 13:49:58 +0900 JST  90        dtan4/awesome-app:7a611fdb41f788dc4f82f8e4aa773f87e5ebd2d5
2017-12-17 13:25:50 +0900 JST  89        dtan4/awesome-app:2005227e9187af26472073df276faaf332e15062
2017-12-15 20:28:09 +0900 JST  88        dtan4/awesome-app:c752436850c05c2c96e3c3373ed9c671c774fd01
2017-12-15 19:16:38 +0900 JST  87        dtan4/awesome-app:b743581f7c00824f341116ad5d28ad6e6d06cb50
2017-12-15 17:25:14 +0900 JST  86        dtan4/awesome-app:48ac909e7df23af5793979eb5c2a9eea0e0fefc0
2017-12-15 15:09:56 +0900 JST  85        dtan4/awesome-app:f238baadf3a243c8829ddce4ab13232582728ec7
2017-12-15 11:50:07 +0900 JST  84        dtan4/awesome-app:db4cba4bce76e88c2759e34913f46fbb3b2217a4
2017-12-14 18:19:36 +0900 JST  83        dtan4/awesome-app:0550e21decf1d7af4bae256b380b8ebf630520c4
2017-12-13 16:12:57 +0900 JST  82        dtan4/awesome-app:a7c26cd85a71c629c25e4ccd9441e69fb5b70bb2
2017-12-13 13:42:38 +0900 JST  81        dtan4/awesome-app:e0c2f581ede3f66a6eefb7ef126a08d70733b624
```

NOTE: deployment owner field will be added in the next patch.