### PR TITLE
Check history length before extracting

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -77,7 +77,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 		lines := formatHistory(rs, tcs[d.Name()])
 		sort.Sort(sort.Reverse(sort.StringSlice(lines)))
 
-		if !historyOpts.all {
+		if !historyOpts.all && len(lines) > defaultHistoryLimit {
 			lines = lines[0:defaultHistoryLimit]
 		}
 


### PR DESCRIPTION
## Why

If the target Deployment has less than 10 ReplicaSets, `k8ship history` raises panic.

```
$ bin/k8ship history -n dtan4-guestbook
===== frontend =====
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/dtan4/k8ship/cmd.doHistory(0x29ab340, 0xc4203bbaa0, 0x0, 0x2, 0x0, 0x0)
        /Users/dtan4/src/github.com/dtan4/k8ship/cmd/history.go:81 +0xc30
github.com/dtan4/k8ship/vendor/github.com/spf13/cobra.(*Command).execute(0x29ab340, 0xc4203bba20, 0x2, 0x2, 0x29ab340, 0xc4203bba20)
        /Users/dtan4/src/github.com/dtan4/k8ship/vendor/github.com/spf13/cobra/command.go:647 +0x3f1
github.com/dtan4/k8ship/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x29abbc0, 0xc42011e690, 0x29b5bc8, 0x20dfba2)
        /Users/dtan4/src/github.com/dtan4/k8ship/vendor/github.com/spf13/cobra/command.go:726 +0x2fe
github.com/dtan4/k8ship/vendor/github.com/spf13/cobra.(*Command).Execute(0x29abbc0, 0x0, 0x7)
        /Users/dtan4/src/github.com/dtan4/k8ship/vendor/github.com/spf13/cobra/command.go:685 +0x2b
github.com/dtan4/k8ship/cmd.Execute()
        /Users/dtan4/src/github.com/dtan4/k8ship/cmd/root.go:28 +0x31
main.main()
        /Users/dtan4/src/github.com/dtan4/k8ship/main.go:6 +0x20
```

## WHAT

Check the current number of ReplicaSets before extracting.