### PR TITLE
Replace "DEPLOYED IMAGE" to "IMAGE" in header

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -86,7 +86,7 @@ func doHistory(cmd *cobra.Command, args []string) error {
 			"DEPLOYED AT",
 			"REVISION",
 			"USER",
-			"DEPLOYED IMAGE",
+			"IMAGE",
 		}
 		fmt.Fprintln(w, strings.Join(headers, "\t"))
 


### PR DESCRIPTION
### before

```sh-session
$ bin/k8ship history -n dtan4-guestbook --all
===== frontend =====
DEPLOYED AT                    REVISION  USER          DEPLOYED IMAGE
2017-12-18 18:12:40 +0900 JST  14        dtan4         gcr.io/google-samples/gb-frontend:v3
2017-12-18 17:07:03 +0900 JST  13        hogefugapiyo  gcr.io/google-samples/gb-frontend:v3
2017-12-18 16:48:20 +0900 JST  12        dtan4         gcr.io/google-samples/gb-frontend:v5
```

### after

```sh-session
$ bin/k8ship history -n dtan4-guestbook --all
===== frontend =====
DEPLOYED AT                    REVISION  USER          IMAGE
2017-12-18 18:12:40 +0900 JST  14        dtan4         gcr.io/google-samples/gb-frontend:v3
2017-12-18 17:07:03 +0900 JST  13        hogefugapiyo  gcr.io/google-samples/gb-frontend:v3
2017-12-18 16:48:20 +0900 JST  12        dtan4         gcr.io/google-samples/gb-frontend:v5
```